### PR TITLE
Create Azure AD Connect TLS1.2 fix

### DIFF
--- a/Azure AD Connect TLS1.2 fix
+++ b/Azure AD Connect TLS1.2 fix
@@ -1,0 +1,6 @@
+>[!ALERT]
+>Azure AD Connect now requires TLS1.2 as the default security protocol. If you receive an error attempting to install or run the Azure AD Connect tool, please open a new Powershell window as Administrator and enter the following command:
+>
+>```Powershell
+>;[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 
+>```


### PR DESCRIPTION
Fix for the Azure Active Directory Connect tool needs TLS1.2 error

This is Mike S.