### PR TITLE
Update power-BI-account.md

### DIFF
--- a/MOC/en/power-BI-account.md
+++ b/MOC/en/power-BI-account.md
@@ -7,7 +7,7 @@
     - **Email**: +++@lab.CloudPortalCredential(User1).Username+++
     - **Password**: +++@lab.CloudPortalCredential(User1).Password+++
 
-3. Complete the sign up process to create a new account, entering the phone number +++555 1234567+++ when prompted.
+3. Complete the sign up process to create a new account. If prompted for a phone number, enter +++555 1234567+++ 
 
 ## Activate a Fabric trial
 


### PR DESCRIPTION
Vitaly wants a conditional statement added because being prompted for a phone number on sign-up has been inconsistent over the past year.

Changed: 

> Complete the sign up process to create a new account, entering the phone number +++555 1234567+++ when prompted.

to 

> Complete the sign up process to create a new account. If prompted for a phone number, enter +++555 1234567+++  