### PR TITLE
Add DP-750 lab instructions for login process

### DIFF
--- a/MOC/en/DP-3011-Setup.md
+++ b/MOC/en/DP-3011-Setup.md
@@ -13,7 +13,7 @@ Sign into Windows using the following credentials:
 
 During the exercises, use the following credentials to sign into the @lab.CloudSubscription.Name Azure subscription that is provided for you (you can also find this information on the **Resources** tab of this pane):
 
-- **User name**: +++@lab.CloudPortalCredential(User1).Username+++
-- **TAP**: +++@lab.CloudPortalCredential(User1).AccessToken+++
+- **User name**: +++@lab.CloudPortalCredential(User1-).Username+++
+- **TAP**: +++@lab.CloudPortalCredential(User1-).AccessToken+++
 
 Use the **Next >** button at the bottom of this pane to move to the first exercise.

--- a/MOC/en/DP-3011-Setup.md
+++ b/MOC/en/DP-3011-Setup.md
@@ -13,7 +13,7 @@ Sign into Windows using the following credentials:
 
 During the exercises, use the following credentials to sign into the @lab.CloudSubscription.Name Azure subscription that is provided for you (you can also find this information on the **Resources** tab of this pane):
 
-- **User name**: +++@lab.CloudPortalCredential(User1-).Username+++
-- **TAP**: +++@lab.CloudPortalCredential(User1-).AccessToken+++
+- **User name**: +++@lab.CloudPortalCredential(User1).Username+++
+- **TAP**: +++@lab.CloudPortalCredential(User1).AccessToken+++
 
 Use the **Next >** button at the bottom of this pane to move to the first exercise.

--- a/MOC/en/DP-750.md
+++ b/MOC/en/DP-750.md
@@ -1,5 +1,3 @@
-# DP-750 labs
-
 ## Login
 
 1. Hello @lab.User.FirstName, on @lab.VirtualMachine(SEA-DEV).SelectLink click @lab.CtrlAltDelete to activate the Ctrl + Alt + Delete sequence and bring up the logon page.

--- a/MOC/en/DP-750.md
+++ b/MOC/en/DP-750.md
@@ -8,7 +8,7 @@
 
 During the exercises, use the following credentials to sign into the @lab.CloudSubscription.Name Azure subscription that is provided for you (you can also find this information on the **Resources** tab of this pane):
 
-- **User name**: +++@lab.CloudPortalCredential(User1-).Username+++
-- **TAP**: +++@lab.CloudPortalCredential(User1-).AccessToken+++
+- **User name**: +++@lab.CloudPortalCredential(User1).Username+++
+- **TAP**: +++@lab.CloudPortalCredential(User1).AccessToken+++
 
 Use the **Next >** button at the bottom of this pane to proceed to the lab.

--- a/MOC/en/DP-750.md
+++ b/MOC/en/DP-750.md
@@ -8,7 +8,7 @@
 
 1. Open the Edge browser, open a new tab, and go to +++https://portal.azure.com+++.
 
-1. Sign in to the Azure portal withthe following credentials (you can also find this information on the **Resources** tab of this pane):
+1. Sign in to the Azure portal with the following credentials (you can also find this information on the **Resources** tab of this pane):
 
 - **User name**: +++@lab.CloudPortalCredential(User1).Username+++
 - **TAP**: +++@lab.CloudPortalCredential(User1).AccessToken+++

--- a/MOC/en/DP-750.md
+++ b/MOC/en/DP-750.md
@@ -11,6 +11,6 @@
 1. Sign in to the Azure portal with the following credentials (you can also find this information on the **Resources** tab of this pane):
 
 - **User name**: +++@lab.CloudPortalCredential(User1).Username+++
-- **TAP**: +++@lab.CloudPortalCredential(User1).AccessToken+++
+- **Temporary Access Pass (TAP)**: +++@lab.CloudPortalCredential(User1).AccessToken+++
 
 Use the **Next >** button at the bottom of this pane to proceed to the lab.

--- a/MOC/en/DP-750.md
+++ b/MOC/en/DP-750.md
@@ -1,0 +1,16 @@
+# DP-750 labs
+
+## Login
+
+1. Hello @lab.User.FirstName, on @lab.VirtualMachine(SEA-DEV).SelectLink click @lab.CtrlAltDelete to activate the Ctrl + Alt + Delete sequence and bring up the logon page.
+
+    >[!KNOWLEDGE] Any links like the one above will send Ctrl+Alt+Delete to the selected machine. This can also be done by the **Keyboard** menu in the upper-left hand corner of the screen.
+
+1. Sign in as +++@lab.VirtualMachine(SEA-DEV).Username+++ with the password +++@lab.VirtualMachine(SEA-DEV).Password+++.
+
+During the exercises, use the following credentials to sign into the @lab.CloudSubscription.Name Azure subscription that is provided for you (you can also find this information on the **Resources** tab of this pane):
+
+- **User name**: +++@lab.CloudPortalCredential(User1-).Username+++
+- **TAP**: +++@lab.CloudPortalCredential(User1-).AccessToken+++
+
+Use the **Next >** button at the bottom of this pane to proceed to the lab.

--- a/MOC/en/DP-750.md
+++ b/MOC/en/DP-750.md
@@ -6,7 +6,9 @@
 
 1. Sign in as +++@lab.VirtualMachine(SEA-DEV).Username+++ with the password +++@lab.VirtualMachine(SEA-DEV).Password+++.
 
-During the exercises, use the following credentials to sign into the @lab.CloudSubscription.Name Azure subscription that is provided for you (you can also find this information on the **Resources** tab of this pane):
+1. Open the Edge browser, open a new tab, and go to +++https://portal.azure.com+++.
+
+1. Sign in to the Azure portal withthe following credentials (you can also find this information on the **Resources** tab of this pane):
 
 - **User name**: +++@lab.CloudPortalCredential(User1).Username+++
 - **TAP**: +++@lab.CloudPortalCredential(User1).AccessToken+++


### PR DESCRIPTION
This pull request adds a new lab instruction file for DP-750, providing step-by-step login instructions and credential details for lab users.

Lab documentation:

* Added a new file `MOC/en/DP-750.md` containing detailed login steps for the SEA-DEV virtual machine, including instructions for sending Ctrl+Alt+Delete, signing in with provided credentials, and accessing the Azure subscription.