### PR TITLE
Update DP-750 lab instructions to correct virtual machine username

### DIFF
--- a/MOC/en/DP-750.md
+++ b/MOC/en/DP-750.md
@@ -4,7 +4,7 @@
 
     >[!KNOWLEDGE] Any links like the one above will send Ctrl+Alt+Delete to the selected machine. This can also be done by the **Keyboard** menu in the upper-left hand corner of the screen.
 
-1. Sign in as +++@lab.VirtualMachine(SEA-DEV).Username+++ with the password +++@lab.VirtualMachine(SEA-DEV).Password+++.
+1. Sign in as +++@lab.VirtualMachine(DP-750-VM).Username+++ with the password +++@lab.VirtualMachine(DP-750-VM).Password+++.
 
 1. Open the Edge browser, open a new tab, and go to +++https://portal.azure.com+++.
 


### PR DESCRIPTION
…ference
This pull request updates the virtual machine credentials in the `MOC/en/DP-750.md` instructions to reference the correct VM for the DP-750 lab.

- Lab instructions:
  * Updated the sign-in step to use `DP-750-VM` credentials instead of `SEA-DEV` credentials.